### PR TITLE
Replacing Bewithaman/s3 to plugins/s3

### DIFF
--- a/src/harness-sto/README.md
+++ b/src/harness-sto/README.md
@@ -125,7 +125,7 @@ dependencies:
 | sto-manager.s3UploadImage.image.digest | string | `""` |  |
 | sto-manager.s3UploadImage.image.pullPolicy | string | `"IfNotPresent"` |  |
 | sto-manager.s3UploadImage.image.registry | string | `"docker.io"` |  |
-| sto-manager.s3UploadImage.image.repository | string | `"bewithaman/s3"` |  |
+| sto-manager.s3UploadImage.image.repository | string | `"plugins/s3"` |  |
 | sto-manager.s3UploadImage.image.tag | string | `"latest"` |  |
 | sto-manager.securityContext | object | `{}` |  |
 | sto-manager.securityImage.image.digest | string | `""` |  |

--- a/src/harness-sto/values.yaml
+++ b/src/harness-sto/values.yaml
@@ -149,7 +149,7 @@ sto-manager:
   s3UploadImage:
     image:
       registry: docker.io
-      repository: bewithaman/s3
+      repository: plugins/s3
       pullPolicy: IfNotPresent
       tag: latest
       digest: ""

--- a/src/sto-manager/README.md
+++ b/src/sto-manager/README.md
@@ -85,7 +85,7 @@ A Helm chart for Kubernetes
 | s3UploadImage.image.imagePullSecrets | list | `[]` |  |
 | s3UploadImage.image.pullPolicy | string | `"IfNotPresent"` |  |
 | s3UploadImage.image.registry | string | `"docker.io"` |  |
-| s3UploadImage.image.repository | string | `"bewithaman/s3"` |  |
+| s3UploadImage.image.repository | string | `"plugins/s3"` |  |
 | s3UploadImage.image.tag | string | `"latest"` |  |
 | securityContext | object | `{}` |  |
 | securityImage.image.digest | string | `""` |  |

--- a/src/sto-manager/values.yaml
+++ b/src/sto-manager/values.yaml
@@ -102,7 +102,7 @@ leImage:
 s3UploadImage:
   image:
     registry: docker.io
-    repository: bewithaman/s3
+    repository: plugins/s3
     pullPolicy: IfNotPresent
     tag: latest
     digest: ""


### PR DESCRIPTION
Description:
Bewithaman/s3 has critical vulnerabilities and therefor needs to be replaced with plugins/s3

JIRA: https://harness.atlassian.net/browse/CI-8325

Replacing Bewithaman/s3 to plugins/s3 image.
Replaced image for harness-sto and sto-manager
Updated README.md for both

Testing:
Tested manually using helm template, no longer seeing bewithaman/s3 image

Revert plan:
Minor changes, PR can be reverted