### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/harness-sto/values.yaml
+++ b/src/harness-sto/values.yaml
@@ -71,7 +71,6 @@ sto-core:
 
   resources:
     # limits:
-    #   cpu: 100m
     #   memory: 128Mi
     requests:
       cpu: 500m
@@ -243,7 +242,6 @@ sto-manager:
 
   resources:
     # limits:
-    #   cpu: 100m
     #   memory: 128Mi
     requests:
       cpu: 1

--- a/src/sto-core/values.yaml
+++ b/src/sto-core/values.yaml
@@ -71,7 +71,6 @@ service:
 
 resources:
   # limits:
-  #   cpu: 100m
   #   memory: 128Mi
   requests:
     cpu: 500m

--- a/src/sto-manager/values.yaml
+++ b/src/sto-manager/values.yaml
@@ -176,7 +176,6 @@ ingress:
   #      - chart-example.local
 resources:
   # limits:
-  #   cpu: 100m
   #   memory: 128Mi
   requests:
     cpu: 1


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)